### PR TITLE
feat: add Opera and Opera GX browser cache support

### DIFF
--- a/src/sifty/core/junk.py
+++ b/src/sifty/core/junk.py
@@ -29,6 +29,10 @@ def _local_appdata() -> Path | None:
     return _env_path("LOCALAPPDATA")
 
 
+def _roaming_appdata() -> Path | None:
+    return _env_path("APPDATA")
+
+
 def _browser_cache_roots(local: Path) -> list[Path]:
     """Cache directories across ALL profiles of the installed browsers.
 
@@ -59,6 +63,29 @@ def _browser_cache_roots(local: Path) -> list[Path]:
                 cand = profile / sub
                 if cand.is_dir():
                     roots.append(cand)
+
+    # Opera and Opera GX store their User Data under %APPDATA% (roaming), not %LOCALAPPDATA%.
+    appdata = _roaming_appdata()
+    if appdata:
+        opera_user_data = [
+            appdata / "Opera Software" / "Opera Stable",
+            appdata / "Opera Software" / "Opera GX Stable",
+        ]
+        for user_data in opera_user_data:
+            if not user_data.is_dir():
+                continue
+            try:
+                profiles = [
+                    p for p in user_data.iterdir()
+                    if p.is_dir() and (p.name == "Default" or p.name.startswith("Profile"))
+                ]
+            except OSError:
+                continue
+            for profile in profiles:
+                for sub in ("Cache", "Code Cache", "GPUCache"):
+                    cand = profile / sub
+                    if cand.is_dir():
+                        roots.append(cand)
 
     firefox_profiles = local / "Mozilla" / "Firefox" / "Profiles"
     if firefox_profiles.is_dir():
@@ -108,7 +135,7 @@ def junk_categories(config=None) -> list[JunkCategory]:
         cats.append(
             JunkCategory(
                 "browser-cache", "Browser caches",
-                "On-disk caches for every Chrome/Edge/Brave/Vivaldi profile and "
+                "On-disk caches for every Chrome/Edge/Brave/Vivaldi/Opera profile and "
                 "Firefox (never cookies, history, or passwords).",
                 _browser_cache_roots(local),
             )


### PR DESCRIPTION
## What does this PR do?

Adds Opera and Opera GX to the browser-cache junk category. Closes #2

Opera stores its User Data under `%APPDATA%\Opera Software\Opera Stable` and `Opera GX Stable` (roaming appdata, not localappdata), with the same Cache/Code Cache/GPUCache layout as other Chromium browsers.

Changes:
- Add `_roaming_appdata()` helper to look up `%APPDATA%`
- - Scan Opera Stable and Opera GX Stable profiles for cache dirs
- - Update browser-cache category description to mention Opera
## Safety checklist

Sifty deletes files, so every PR keeps these promises:

- [ ] `pytest` is green, including `tests/test_safety.py`
- [ ] No new direct deletions (`os.remove`, `shutil.rmtree`, `Path.unlink`); everything goes through `safety.trash()`
- [ ] New destructive paths default to dry-run and ask before applying
- [ ] New core functions have a matching test

## Notes for the reviewer

<!-- Anything you're unsure about, trade-offs, or things to look at closely. -->
