### PR TITLE
(feat) add Discord cache category to junk cleaner

### DIFF
--- a/src/sifty/core/junk.py
+++ b/src/sifty/core/junk.py
@@ -72,6 +72,30 @@ def _browser_cache_roots(local: Path) -> list[Path]:
 
     return roots
 
+def _discord_cache_roots() -> list[Path]:
+    """Cache directories for Discord, Discord PTB, and Discord Canary.
+
+    Only returns specific Chromium cache paths - never login session,
+    local storage, or settings data.
+    """
+    roots: list[Path] = []
+    appdata = _env_path("APPDATA")
+    if not appdata:
+        return roots
+
+    flavors = ["discord", "discordptb", "discordcanary"]
+    cache_subs = ["Cache", "Code Cache", "GPUCache"]
+
+    for flavor in flavors:
+        flavor_dir = appdata / flavor
+        if not flavor_dir.is_dir():
+            continue
+        for sub in cache_subs:
+            cand = flavor_dir / sub
+            if cand.is_dir():
+                roots.append(cand)
+
+    return roots
 
 def junk_categories(config=None) -> list[JunkCategory]:
     """Build the list of junk categories from the environment + config."""
@@ -189,6 +213,17 @@ def junk_categories(config=None) -> list[JunkCategory]:
             JunkCategory(
                 "onedrive-logs", "OneDrive sync logs",
                 "OneDrive diagnostic logs (rebuilt automatically).", [od_logs],
+            )
+        )
+
+    # Discord caches (Chromium style, safe to clear)
+    discord_roots = _discord_cache_roots()
+    if discord_roots:
+        cats.append(
+            JunkCategory(
+                "discord-cache", "Discord cache",
+                "On-disk caches for Discord, PTB, and Canary channels (never login session data).",
+                discord_roots,
             )
         )
 

--- a/tests/test_junk.py
+++ b/tests/test_junk.py
@@ -104,3 +104,37 @@ def test_downloads_installers_gated_by_config(monkeypatch, tmp_path):
     cfg_on.data["junk"] = {"include_downloads_installers": True}
     keys_on = {c.key for c in junk.junk_categories(cfg_on)}
     assert "downloads-installers" in keys_on
+
+
+def test_discord_cache_category_covers_flavors_and_safeguards_session(monkeypatch, tmp_path):
+    appdata = tmp_path / "appdata"
+
+    for flavor in ("discord", "discordptb", "discordcanary"):
+        flavor_dir = appdata / flavor
+        (flavor_dir / "Cache").mkdir(parents=True)
+        (flavor_dir / "Code Cache").mkdir(parents=True)
+        (flavor_dir / "GPUCache").mkdir(parents=True)
+        (flavor_dir / "Local Storage").mkdir(parents=True)
+
+    original_env_path = junk._env_path
+    monkeypatch.setattr(junk, "_env_path", lambda var: appdata if var == "APPDATA" else original_env_path(var))
+
+    monkeypatch.setenv("TEMP", str(tmp_path / "temp"))
+    monkeypatch.setenv("TMP", str(tmp_path / "temp"))
+    monkeypatch.setenv("SystemRoot", str(tmp_path / "win"))
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path / "home"))
+
+    cats = {c.key: c for c in junk.junk_categories(Config())}
+
+    # Verification 1: Category exists
+    assert "discord-cache" in cats
+
+    roots = {str(r) for r in cats["discord-cache"].roots}
+
+    # Verification 2: Specific caches are included
+    assert str(appdata / "discord" / "Cache") in roots
+    assert str(appdata / "discordptb" / "Code Cache") in roots
+    assert str(appdata / "discordcanary" / "GPUCache") in roots
+
+    # Verification 3: Crucial session paths are ignored
+    assert not any("Local Storage" in r for r in roots)


### PR DESCRIPTION
## What does this PR do?

This PR addresses the issue regarding Discord's large Chromium-style cache accumulation. It adds a new dedicated junk category `discord-cache` that identifies and targets safe-to-clear cache directories for Discord and its alternative release channels (PTB and Canary), while strictly preserving user session and login data. 
Closes #3 

## Safety checklist

Sifty deletes files, so every PR keeps these promises:

- [x] `pytest` is green, including `tests/test_safety.py`
- [x] No new direct deletions (`os.remove`, `shutil.rmtree`, `Path.unlink`); everything goes through `safety.trash()`
- [x] New destructive paths default to dry-run and ask before applying
- [x] New core functions have a matching test

## Notes for the reviewer

- **Scope:** The `discord-cache` category safely covers standard Discord, Discord PTB, and Discord Canary by looking at their respective directories in `%APPDATA%`.
- **Targeted directories:** It only targets `Cache`, `Code Cache`, and `GPUCache` subdirectories. 
- **Safety Carve-out:** Vital user session data (such as `Local Storage`) is strictly left untouched to ensure users are never logged out of their accounts after a cleanup.
- **Testing:** A comprehensive sandbox test has been added to `tests/test_junk.py` to validate flavor discovery and ensure session folders are never included in the roots.
-  **Manual Test:** I installed and tested this implementation locally with my own Discord client; the script successfully detected and staged the cache directories for deletion during the dry-run, and my account session remained perfectly active and unaffected afterwards.