### PR TITLE
Proactive maintenance agent + anomaly detection (0.9.0)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -42,7 +42,7 @@ body:
     attributes:
       label: Sifty version
       description: Output of `sifty version`.
-      placeholder: 0.8.0
+      placeholder: 0.9.0
     validations:
       required: true
   - type: textarea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ public release were development milestones.
   Bin and undoable from Reports. Off by default: it only notifies.
 - **AI summary on Home**: when the local model is available, the Home checkup
   shows a short plain-language read on what matters most and what to do first.
+- **Run agent from Home**: a "Run agent" button runs the whole proactive pass
+  and cleans the low-risk allowlist to the Recycle Bin behind a confirm, showing
+  the checkup, any anomalies, and what it cleaned right there.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to Sifty. The format loosely follows
 [Keep a Changelog](https://keepachangelog.com); versions before the first
 public release were development milestones.
 
+## [0.9.0] - 2026-07
+
+### Added
+
+- **Proactive maintenance agent**: `sifty agent run` does a full read-only
+  checkup plus anomaly detection and toasts a short summary. Schedule it with
+  `sifty agent schedule` to have Sifty keep an eye on things in the background.
+- **Anomaly detection**: Sifty now notices change over time - a drive that lost
+  a lot of free space, junk piling up fast, or a new program added to Windows
+  startup - and surfaces it in the checkup, the Home screen, and the AI's
+  context. Baselines are stored locally (sizes and startup names only).
+- **Opt-in unattended auto-fix**: with `[agent].auto_fix` turned on, the
+  scheduled run may auto-clean a small, fixed allowlist of per-user cache/temp
+  junk (never system or admin locations, never your files), all to the Recycle
+  Bin and undoable from Reports. Off by default: it only notifies.
+- **AI summary on Home**: when the local model is available, the Home checkup
+  shows a short plain-language read on what matters most and what to do first.
+
+### Changed
+
+- The Home checkup now lists notable changes as their own reviewable rows, each
+  linking to the screen where you can act on them.
+
 ## [0.8.0] - 2026-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -182,6 +182,10 @@ sifty ai autonomy low_risk_auto        # how much the agent does before asking
 sifty ai policy set clean_junk auto    # per-tool: auto / ask / never
 sifty ai policy list                   # see every tool and what it will do
 
+# Proactive agent: checkup + anomaly scan, toast a summary
+sifty agent run                        # notify only (never deletes)
+sifty agent schedule --sc DAILY --time 09:00   # run it in the background
+
 # Scripting: JSON output on read-only commands (auto-enabled when piped)
 sifty --json checkup
 sifty --json disk volumes

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -106,6 +106,22 @@ learned preferences. `core/ai_memory.py` (a separate `ai_memory.db`, kept out of
 `history.db` undo ledger) persists the chat transcript and the tool skips those
 preferences are derived from.
 
+## Proactive agent
+
+`core/agent_run.py` is what a scheduled `sifty agent run` executes: a read-only
+`checkup` + `anomaly.detect()`, then a toast summarizing what it found. It may also
+auto-clean, but only under strict rails - this is the one place Sifty can delete
+with no human present. The auto-fix set is a **hardcoded allowlist** of per-user
+cache/temp categories (config can only narrow it), every admin/system category is
+excluded, and the LLM is never asked what to delete here - the background path calls
+`junk.clean()` directly and records the run so `sifty undo` still works. It is off by
+default (`[agent].auto_fix`): the scheduled run only notifies unless you opt in.
+
+`core/anomaly.py` keeps a small time-series baseline (`snapshots.db`, separate from
+`history.db` and `ai_memory.db`) of disk-free, junk totals, and startup names, and
+flags notable change - a fast free-space drop, junk growth, a new startup entry. Its
+findings feed the toast, the AI context, and the Home checkup.
+
 ## Testing strategy
 
 - `pyproject.toml` sets `pythonpath = ["src"]` so tests import `sifty` without an

--- a/packaging/installer/sifty.iss
+++ b/packaging/installer/sifty.iss
@@ -12,7 +12,7 @@
 ; Output lands in dist\sifty-setup.exe (next to the bare exe it wraps).
 
 #ifndef AppVersion
-  #define AppVersion "0.8.0"
+  #define AppVersion "0.9.0"
 #endif
 
 #define AppName "Sifty"

--- a/site/index.html
+++ b/site/index.html
@@ -28,7 +28,7 @@
     "description": "An open source Windows maintenance CLI and TUI that cleans junk, finds duplicate files, manages apps and updates, and purges developer clutter. Dry-run by default, deletes only to the Recycle Bin, and every clean can be undone.",
     "url": "https://sifty.tech/",
     "downloadUrl": "https://github.com/Vortrix5/sifty/releases/latest",
-    "softwareVersion": "0.8.0",
+    "softwareVersion": "0.9.0",
     "license": "https://opensource.org/licenses/MIT",
     "image": "https://sifty.tech/assets/social-preview.png",
     "screenshot": "https://sifty.tech/assets/demo.gif",

--- a/src/sifty/__init__.py
+++ b/src/sifty/__init__.py
@@ -1,3 +1,3 @@
 """Sifty: a Windows maintenance CLI that sifts the junk from the keep."""
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"

--- a/src/sifty/ai/advisor.py
+++ b/src/sifty/ai/advisor.py
@@ -61,6 +61,27 @@ def summarize_disk(client: OllamaClient, items: list[tuple[str, str]], question:
     )
 
 
+def summarize_checkup(client: OllamaClient, findings: list, anomalies: list) -> str | None:
+    """A short, plain-language read on a checkup + anomalies (metadata only).
+
+    ``findings`` are checkup.Finding objects, ``anomalies`` are anomaly.Anomaly
+    objects. Returns None when the AI is unavailable so the caller can hide the
+    summary rather than show an error.
+    """
+    lines = [f"- {f.label}: {f.summary} [{f.severity}]" for f in findings]
+    lines += [f"- Change noticed: {a.summary} [{a.severity}]" for a in anomalies]
+    if not lines:
+        return None
+    listing = "\n".join(lines)
+    return _safe(
+        client,
+        "Here is the result of a Windows maintenance checkup on this machine:\n"
+        f"{listing}\n\n"
+        "In 2-3 sentences, tell the user what matters most and what to do first. "
+        "Be concrete and calm; don't invent findings that aren't listed.",
+    )
+
+
 def suggest_organization(client: OllamaClient, sample_names: list[str]) -> str | None:
     """Propose a folder scheme for a messy directory from sample filenames."""
     listing = "\n".join(f"- {n}" for n in sample_names[:40])

--- a/src/sifty/ai/context.py
+++ b/src/sifty/ai/context.py
@@ -15,7 +15,8 @@ from ..console import human_size
 
 
 def build(*, include_junk: bool = True, include_volumes: bool = True,
-          include_history: bool = True, include_preferences: bool = True) -> str:
+          include_history: bool = True, include_preferences: bool = True,
+          include_anomalies: bool = True) -> str:
     """Return a Markdown-formatted system context string for injection into prompts."""
     sections: list[str] = []
 
@@ -26,6 +27,11 @@ def build(*, include_junk: bool = True, include_volumes: bool = True,
 
     if include_junk:
         section = _junk_section()
+        if section:
+            sections.append(section)
+
+    if include_anomalies:
+        section = _anomaly_section()
         if section:
             sections.append(section)
 
@@ -94,6 +100,21 @@ def _history_section() -> str:
     ]
     for r in runs[:3]:
         lines.append(f"- {r.ts[:10]}: {r.action} - {human_size(r.bytes_freed)} freed")
+    return "\n".join(lines)
+
+
+def _anomaly_section() -> str:
+    """Recent notable changes (disk drops, junk growth, new startup entries)."""
+    try:
+        from ..core import anomaly
+        found = anomaly.detect()
+    except Exception:
+        return ""
+    if not found:
+        return ""
+    lines = ["**Recent changes noticed:**"]
+    for a in found:
+        lines.append(f"- {a.summary}")
     return "\n".join(lines)
 
 

--- a/src/sifty/cli/app.py
+++ b/src/sifty/cli/app.py
@@ -15,6 +15,7 @@ from ..infra.logging import get_logger, log_file, setup_logging
 from ..windows.admin import is_admin, relaunch_as_admin
 from . import output
 from .commands import (
+    agent,
     ai_group,
     apps,
     cleanup,
@@ -53,6 +54,7 @@ app.add_typer(updates.app, name="update")
 app.add_typer(organize.app, name="organize")
 app.add_typer(watch.app, name="watch")
 app.add_typer(ai_group.app, name="ai")
+app.add_typer(agent.app, name="agent")
 app.add_typer(config_cmd.app, name="config")
 
 

--- a/src/sifty/cli/commands/agent.py
+++ b/src/sifty/cli/commands/agent.py
@@ -1,0 +1,135 @@
+"""`sifty agent` - proactive maintenance: checkup, notify, and optional auto-fix.
+
+`agent run` does a read-only checkup + anomaly scan and toasts a summary. It only
+DELETES when told to: a foreground run needs an explicit ``--apply``; the
+scheduled ``--background`` run auto-cleans only if ``[agent].auto_fix`` is on in
+the config. Either way it touches just the hardcoded low-risk allowlist in
+``core/agent_run.py`` and routes through the Recycle Bin.
+"""
+
+from __future__ import annotations
+
+import typer
+
+from ...console import console, error, human_size, success
+from ...core import agent_run, schedule
+from ...infra.config import load_config
+from ...windows import scheduler
+from .. import output
+
+app = typer.Typer(
+    no_args_is_help=True,
+    help="Proactive maintenance agent: checkup, notify, and optional auto-fix.",
+)
+
+
+@app.command("run")
+def run_cmd(
+    apply: bool = typer.Option(
+        False, "--apply", help="Auto-clean approved low-risk junk now (foreground opt-in)."
+    ),
+    background: bool = typer.Option(
+        False, "--background", help="Quiet mode for the scheduler: toast only, no console output."
+    ),
+) -> None:
+    """Run a proactive checkup; toast a summary or auto-fix approved low-risk junk."""
+    config = load_config()
+    # config auto_fix only takes effect for the scheduled/background run; a
+    # foreground run must opt in explicitly with --apply.
+    if background:
+        do_apply = bool(config.section("agent").get("auto_fix", False))
+    else:
+        do_apply = apply
+    result = agent_run.run_agent(apply=do_apply, config=config)
+
+    if background:
+        return  # the toast (if any) is the whole output
+
+    if output.json_enabled():
+        output.emit(_result_json(result))
+        return
+
+    _print_result(result)
+
+
+def _result_json(result) -> dict:
+    return {
+        "headline": result.headline,
+        "notified": result.notified,
+        "findings": [
+            {"domain": f.domain, "summary": f.summary, "severity": f.severity}
+            for f in result.findings
+        ],
+        "anomalies": [
+            {"kind": a.kind, "summary": a.summary, "severity": a.severity}
+            for a in result.anomalies
+        ],
+        "auto_fixed": (
+            {
+                "categories": result.auto_fixed.category_keys,
+                "items": result.auto_fixed.items,
+                "bytes_freed": result.auto_fixed.bytes_freed,
+            }
+            if result.auto_fixed else None
+        ),
+    }
+
+
+_DOT = {"attention": "[red]●[/red]", "info": "[yellow]●[/yellow]", "ok": "[green]●[/green]"}
+
+
+def _print_result(result) -> None:
+    from rich.table import Table
+
+    if result.auto_fixed:
+        a = result.auto_fixed
+        success(f"Auto-cleaned {a.items:,} items ({human_size(a.bytes_freed)}) to the Recycle Bin.")
+
+    table = Table(title="Checkup", title_style="bold")
+    for col in ("Area", "Result", "Severity"):
+        table.add_column(col)
+    for f in result.findings:
+        table.add_row(f.label, f.summary, f"{_DOT.get(f.severity, '')} {f.severity}")
+    console.print(table)
+
+    if result.anomalies:
+        console.print("\n[b]Recent changes:[/b]")
+        for a in result.anomalies:
+            console.print(f"  {_DOT.get(a.severity, '')} {a.summary}")
+
+    if result.elevated_skipped:
+        console.print(
+            f"\n[dim]{len(result.elevated_skipped)} admin-only categor(y/ies) left alone; "
+            f"run `sifty --admin junk clean` to include them.[/dim]"
+        )
+
+    if not result.auto_fixed and result.headline:
+        console.print(f"\n[dim]{result.headline}[/dim]")
+
+
+@app.command("schedule")
+def schedule_cmd(
+    sc: str = typer.Option("DAILY", "--sc", help="DAILY or WEEKLY."),
+    day: str = typer.Option("SUN", "--day", help="Day for WEEKLY (MON..SUN)."),
+    time: str = typer.Option("09:00", "--time", help="Start time, HH:MM (24h)."),
+) -> None:
+    """Schedule the proactive agent to run periodically."""
+    ok, message = scheduler.create("agent", schedule.agent_command(), sc.upper(), day.upper(), time)
+    if ok:
+        success(f"Scheduled the maintenance agent ({sc.lower()} {time}).")
+        auto = load_config().section("agent").get("auto_fix", False)
+        mode = "auto-clean low-risk junk" if auto else "notify only"
+        console.print(f"[dim]Mode: {mode} (set [agent] auto_fix in your config to change).[/dim]")
+    else:
+        error(f"Failed to create task: {message}")
+        raise typer.Exit(1)
+
+
+@app.command("unschedule")
+def unschedule_cmd() -> None:
+    """Remove the scheduled maintenance agent."""
+    if scheduler.delete("agent"):
+        success("Removed the maintenance agent task.")
+    else:
+        error("No agent task to remove.")
+        raise typer.Exit(1)

--- a/src/sifty/core/agent_run.py
+++ b/src/sifty/core/agent_run.py
@@ -1,0 +1,144 @@
+"""The proactive maintenance agent (background run).
+
+`run_agent` is what a scheduled `sifty agent run` executes: a read-only checkup
+plus anomaly detection, then EITHER a toast summarizing what it found (the
+default) OR, only when explicitly opted in, an unattended auto-clean of a
+narrow set of low-risk junk.
+
+Safety model - this is the one place Sifty may delete with no human present, so
+the rails are deliberately strict:
+
+- The auto-fix set is a **hardcoded allowlist** of per-user cache/temp
+  categories (:data:`_AUTOFIX_ALLOWLIST`). Config can only *narrow* it.
+- Every admin-only / system junk category is excluded, always. The background
+  task runs unelevated and must never silently touch system files.
+- The LLM is never involved in choosing what to delete here; this path calls
+  `junk.clean()` directly with the allowlist. The AI's role in the background is
+  summarization only (that lives in the TUI, not here).
+- Deletion still routes through `core.safety.trash()` (Recycle Bin, protected
+  paths refused, audited) and is recorded in `history` so `sifty undo` works.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+from ..windows import notify
+from . import anomaly, checkup, disk, history, junk
+from .checkup import ATTENTION, INFO, human_size
+
+logger = logging.getLogger("sifty.agent")
+
+__all__ = ["AgentRunResult", "AutoFixOutcome", "run_agent"]
+
+_TITLE = "Sifty maintenance"
+
+# The ONLY junk categories an unattended run may ever clean: per-user,
+# self-rebuilding cache/temp/dump dirs, none of which require admin. This set is
+# the source of truth; config can subset it but not extend it.
+_AUTOFIX_ALLOWLIST = frozenset({
+    "user-temp", "thumbnail-cache", "browser-cache",
+    "winget-cache", "onedrive-logs", "discord-cache", "crash-dumps",
+})
+
+_DEFAULT_MIN_BYTES = 524288000  # 500 MB
+
+
+@dataclass
+class AutoFixOutcome:
+    category_keys: list[str]
+    items: int
+    bytes_freed: int
+    skipped: list[str]
+    run_id: int | None  # history row id, so the clean is undoable
+
+
+@dataclass
+class AgentRunResult:
+    findings: list[checkup.Finding]
+    anomalies: list[anomaly.Anomaly]
+    auto_fixed: AutoFixOutcome | None
+    notified: bool
+    headline: str
+    elevated_skipped: list[str] = field(default_factory=list)
+
+
+def eligible_autofix_keys(config) -> set[str]:
+    """Junk keys the unattended run may clean: (config subset) of the hardcoded
+    allowlist, minus any category that requires admin. Never wider than the
+    allowlist. Independent of whether auto-fix is actually enabled."""
+    configured = set(config.section("agent").get("auto_fix_categories", []))
+    candidate = (configured & _AUTOFIX_ALLOWLIST) if configured else set(_AUTOFIX_ALLOWLIST)
+    admin_keys = {c.key for c in junk.junk_categories(config) if c.requires_admin}
+    return candidate - admin_keys
+
+
+def run_agent(*, apply: bool = False, config=None, notify_fn=None, now=None) -> AgentRunResult:
+    """Run a proactive checkup; auto-fix approved low-risk junk if ``apply``,
+    else notify only. ``notify_fn`` is injected for testing."""
+    from ..infra.config import load_config
+
+    config = config or load_config()
+    notify_fn = notify_fn or notify.toast
+
+    findings = checkup.run_checkup()
+
+    # Current state, computed once and shared with detection + baseline update.
+    vols = disk.volumes()
+    cats = junk.scan(config)
+    junk_total = sum(c.size for c in cats)
+
+    anomalies = anomaly.detect(config=config, volumes=vols, junk_total=junk_total)
+    anomaly.record_snapshot(config=config, volumes=vols, junk_total=junk_total, now=now)
+
+    # Admin-only junk we can see but won't touch unattended (informational).
+    elevated_skipped = sorted(
+        c.category.key for c in cats if c.category.requires_admin and c.size > 0
+    )
+
+    auto_fixed = None
+    if apply:
+        auto_fixed = _auto_fix(config, cats)
+
+    headline = _headline(findings, anomalies, auto_fixed)
+    notified = bool(notify_fn(_TITLE, headline)) if headline else False
+    return AgentRunResult(findings, anomalies, auto_fixed, notified, headline, elevated_skipped)
+
+
+def _auto_fix(config, cats) -> AutoFixOutcome | None:
+    keys = eligible_autofix_keys(config)
+    if not keys:
+        return None
+    min_bytes = int(config.section("agent").get("auto_fix_min_bytes", _DEFAULT_MIN_BYTES))
+    eligible_total = sum(c.size for c in cats if c.category.key in keys)
+    if eligible_total < min_bytes:
+        return None
+    result = junk.clean(config, only=set(keys), dry_run=False)
+    if result.items == 0:
+        return None
+    run_id = history.record_clean(
+        "agent", "auto-fix:" + ",".join(sorted(keys)),
+        result.bytes_freed, result.items, result.trashed,
+    )
+    logger.info("agent auto-fix: %d items, %d bytes, run %s",
+                result.items, result.bytes_freed, run_id)
+    return AutoFixOutcome(sorted(keys), result.items, result.bytes_freed, result.skipped, run_id)
+
+
+def _headline(findings, anomalies, auto_fixed) -> str:
+    """Short toast text. Empty string means 'all clear' - don't nag."""
+    if auto_fixed:
+        return (f"Cleaned {human_size(auto_fixed.bytes_freed)} of junk "
+                f"({auto_fixed.items} items) to the Recycle Bin.")
+
+    urgent = [f"{f.label}: {f.summary}" for f in findings if f.severity == ATTENTION]
+    urgent += [a.summary for a in anomalies if a.severity == "attention"]
+    if urgent:
+        return "Sifty found: " + "; ".join(urgent[:3]) + ". Open Sifty to review."
+
+    minor = [f"{f.label}: {f.summary}" for f in findings if f.severity == INFO]
+    minor += [a.summary for a in anomalies]
+    if minor:
+        return "Sifty noticed: " + "; ".join(minor[:2]) + "."
+    return ""

--- a/src/sifty/core/anomaly.py
+++ b/src/sifty/core/anomaly.py
@@ -1,0 +1,229 @@
+"""Anomaly detection: flag notable changes on the machine over time.
+
+Compares the current state against a small persisted baseline and reports things
+worth a human's attention - a volume that lost a lot of free space, junk piling
+up fast, or a new program that started launching at boot. Strictly read-only:
+detection never deletes or changes anything, it only observes.
+
+The baseline is a compact time series in its own SQLite file
+(``%APPDATA%\\sifty\\snapshots.db``), kept separate from both the undo ledger
+(``history.db``) and the AI store (``ai_memory.db``). Metadata only - free
+bytes, junk totals, and startup entry *names*, never file contents.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+
+from ..infra.config import app_data_dir, load_config
+from .checkup import human_size
+
+logger = logging.getLogger("sifty.core")
+
+__all__ = ["Anomaly", "detect", "record_snapshot"]
+
+_GB = 1 << 30
+_KEEP_PER_SERIES = 60  # rows retained per (kind, key) time series
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS snapshots (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts TEXT NOT NULL,
+    kind TEXT NOT NULL,     -- "disk_free" | "junk_total"
+    key TEXT NOT NULL,      -- volume mountpoint, or "total"
+    value INTEGER NOT NULL
+);
+CREATE TABLE IF NOT EXISTS startup_seen (
+    name TEXT PRIMARY KEY,
+    first_seen TEXT NOT NULL
+);
+"""
+
+
+@dataclass
+class Anomaly:
+    kind: str          # "disk_drop" | "junk_growth" | "new_startup"
+    severity: str      # "info" | "attention"
+    summary: str       # human one-liner
+    action_key: str    # TUI nav key (mirrors checkup.Finding) so UIs can deep-link
+    detail: dict = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Storage
+# ---------------------------------------------------------------------------
+
+def db_path() -> Path:
+    return app_data_dir() / "snapshots.db"
+
+
+def _connect() -> sqlite3.Connection:
+    conn = sqlite3.connect(db_path())
+    conn.executescript(_SCHEMA)
+    return conn
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat(timespec="seconds")
+
+
+def _latest_by_key(conn: sqlite3.Connection, kind: str) -> dict[str, int]:
+    """The most recent stored value per key for a series."""
+    rows = conn.execute(
+        "SELECT key, value FROM snapshots WHERE kind = ? AND id IN "
+        "(SELECT MAX(id) FROM snapshots WHERE kind = ? GROUP BY key)",
+        (kind, kind),
+    ).fetchall()
+    return {r[0]: r[1] for r in rows}
+
+
+# ---------------------------------------------------------------------------
+# Current-state helpers (metadata only)
+# ---------------------------------------------------------------------------
+
+def _current_volumes(volumes=None):
+    if volumes is not None:
+        return volumes
+    from . import disk
+    return disk.volumes()
+
+
+def _current_junk_total(junk_total=None) -> int:
+    if junk_total is not None:
+        return junk_total
+    from . import junk
+    return sum(c.size for c in junk.scan())
+
+
+def _current_startup_names(startup_names=None) -> set[str]:
+    if startup_names is not None:
+        return set(startup_names)
+    from . import startup
+    return {e.name for e in startup.list_entries() if e.enabled}
+
+
+# ---------------------------------------------------------------------------
+# Detection (read-only)
+# ---------------------------------------------------------------------------
+
+def detect(*, config=None, volumes=None, junk_total=None, startup_names=None) -> list[Anomaly]:
+    """Compare the current state to the stored baseline and return anomalies.
+
+    Returns ``[]`` on the very first run (no baseline yet). Never raises - a
+    failed detector is logged and skipped so a background run always completes.
+    Optional current-state args let a caller avoid re-scanning; omit to compute.
+    """
+    config = config or load_config()
+    section = config.section("anomaly")
+    out: list[Anomaly] = []
+    conn = _connect()
+    try:
+        for detector in (
+            lambda: _detect_disk_drop(conn, section, volumes),
+            lambda: _detect_junk_growth(conn, section, junk_total),
+            lambda: _detect_new_startup(conn, section, startup_names),
+        ):
+            try:
+                out.extend(detector())
+            except Exception:
+                logger.debug("anomaly detector failed", exc_info=True)
+    finally:
+        conn.close()
+    return out
+
+
+def _detect_disk_drop(conn, section, volumes) -> list[Anomaly]:
+    threshold = int(section.get("disk_drop_gb", 10)) * _GB
+    priors = _latest_by_key(conn, "disk_free")
+    out: list[Anomaly] = []
+    for v in _current_volumes(volumes):
+        prior = priors.get(v.mountpoint)
+        if prior is None:
+            continue
+        drop = prior - v.free
+        if drop >= threshold:
+            out.append(Anomaly(
+                "disk_drop", "attention",
+                f"{v.mountpoint} lost {human_size(drop)} of free space since the last "
+                f"check ({human_size(v.free)} free now)",
+                "disk", {"mountpoint": v.mountpoint, "drop": drop, "free": v.free},
+            ))
+    return out
+
+
+def _detect_junk_growth(conn, section, junk_total) -> list[Anomaly]:
+    threshold = int(section.get("junk_growth_gb", 5)) * _GB
+    prior = _latest_by_key(conn, "junk_total").get("total")
+    if prior is None:
+        return []
+    current = _current_junk_total(junk_total)
+    growth = current - prior
+    if growth >= threshold:
+        return [Anomaly(
+            "junk_growth", "info",
+            f"Junk grew by {human_size(growth)} since the last check "
+            f"({human_size(current)} reclaimable now)",
+            "junk", {"growth": growth, "current": current},
+        )]
+    return []
+
+
+def _detect_new_startup(conn, section, startup_names) -> list[Anomaly]:
+    if not section.get("flag_new_startup", True):
+        return []
+    seen = {r[0] for r in conn.execute("SELECT name FROM startup_seen").fetchall()}
+    if not seen:
+        return []  # first run: nothing to compare; record_snapshot seeds the baseline
+    new = sorted(_current_startup_names(startup_names) - seen)
+    if not new:
+        return []
+    shown = ", ".join(new[:5]) + (" ..." if len(new) > 5 else "")
+    return [Anomaly(
+        "new_startup", "attention",
+        f"{len(new)} new startup program(s) since the last check: {shown}",
+        "startup", {"names": new},
+    )]
+
+
+# ---------------------------------------------------------------------------
+# Baseline update
+# ---------------------------------------------------------------------------
+
+def record_snapshot(*, config=None, volumes=None, junk_total=None,
+                    startup_names=None, now=None) -> None:
+    """Append the current disk-free + junk-total + startup names to the baseline.
+
+    Idempotent-safe to call every run; prunes each time series to the last
+    :data:`_KEEP_PER_SERIES` rows so the file stays small.
+    """
+    config = config or load_config()
+    ts = now or _now()
+    conn = _connect()
+    try:
+        for v in _current_volumes(volumes):
+            _append(conn, ts, "disk_free", v.mountpoint, int(v.free))
+        _append(conn, ts, "junk_total", "total", int(_current_junk_total(junk_total)))
+        for name in _current_startup_names(startup_names):
+            conn.execute(
+                "INSERT OR IGNORE INTO startup_seen (name, first_seen) VALUES (?, ?)",
+                (name, ts),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _append(conn, ts: str, kind: str, key: str, value: int) -> None:
+    conn.execute(
+        "INSERT INTO snapshots (ts, kind, key, value) VALUES (?, ?, ?, ?)",
+        (ts, kind, key, value),
+    )
+    conn.execute(
+        "DELETE FROM snapshots WHERE kind = ? AND key = ? AND id NOT IN "
+        "(SELECT id FROM snapshots WHERE kind = ? AND key = ? ORDER BY id DESC LIMIT ?)",
+        (kind, key, kind, key, _KEEP_PER_SERIES),
+    )

--- a/src/sifty/core/schedule.py
+++ b/src/sifty/core/schedule.py
@@ -13,7 +13,7 @@ import sys
 from ..infra.config import app_data_dir
 from ..windows import scheduler
 
-__all__ = ["sifty_command", "watch_command", "add", "remove", "list_schedules"]
+__all__ = ["sifty_command", "watch_command", "agent_command", "add", "remove", "list_schedules"]
 
 
 def _file():
@@ -45,6 +45,16 @@ def sifty_command(profile: str) -> str:
 def watch_command(threshold_gb: int) -> str:
     """The command a scheduled task runs to check free space and toast."""
     return f'"{sys.executable}" -m sifty watch check --threshold {threshold_gb}'
+
+
+def agent_command() -> str:
+    """The command a scheduled task runs for a proactive maintenance pass.
+
+    No --apply: whether it auto-cleans is driven by the [agent].auto_fix config,
+    so the task itself is inert-by-default and can't be made destructive by the
+    schedule alone.
+    """
+    return f'"{sys.executable}" -m sifty agent run --background'
 
 
 def add(name: str, profile: str, command: str, sc: str, day: str, time: str) -> tuple[bool, str]:

--- a/src/sifty/infra/config.py
+++ b/src/sifty/infra/config.py
@@ -49,6 +49,29 @@ DEFAULTS: dict[str, Any] = {
         # Free-space threshold (GB) below which `sifty watch check` warns/toasts.
         "threshold_gb": 5,
     },
+    "agent": {
+        # Whether the background `sifty agent run` may DELETE unattended. Off by
+        # default - it only notifies. Turn on to auto-clean low-risk junk.
+        "auto_fix": False,
+        # Junk categories the unattended run may clean when auto_fix is on. This
+        # can only NARROW the hardcoded cache/temp allowlist in core/agent_run.py,
+        # never widen it, and admin-only categories are always excluded.
+        "auto_fix_categories": [
+            "user-temp", "thumbnail-cache", "browser-cache",
+            "winget-cache", "onedrive-logs", "discord-cache", "crash-dumps",
+        ],
+        # Don't auto-clean unless at least this many bytes are reclaimable
+        # (default 500 MB); below it, just notify.
+        "auto_fix_min_bytes": 524288000,
+    },
+    "anomaly": {
+        # Flag a volume that lost at least this much free space since last check.
+        "disk_drop_gb": 10,
+        # Flag junk that grew by at least this much since last check.
+        "junk_growth_gb": 5,
+        # Flag programs newly added to Windows startup.
+        "flag_new_startup": True,
+    },
     "purge": {
         # Extra artifact directory names beyond the built-in ARTIFACT_DIRS set.
         "extra_patterns": [],

--- a/src/sifty/tui/views/home.py
+++ b/src/sifty/tui/views/home.py
@@ -22,7 +22,7 @@ from textual.widgets import Button, Static
 from ...ai import advisor
 from ...ai.client import OllamaClient
 from ...console import human_size
-from ...core import anomaly, checkup, cleanup, disk, history, junk, updates
+from ...core import agent_run, anomaly, checkup, cleanup, disk, history, junk, updates
 from ...core.anomaly import Anomaly
 from ...core.checkup import Finding
 from ...windows.admin import is_admin
@@ -65,6 +65,7 @@ class HomeView(BaseView):
             )
             with Horizontal(classes="actions"):
                 yield Button("Run checkup", id="run-checkup", variant="primary")
+                yield Button("Run agent", id="run-agent")
             yield Static("", id="ai-summary", classes="subtle")
             yield Vertical(id="checkup-results")
         yield Panel(Static("Reading volumes…", id="vol-body"), title="Volumes")
@@ -81,12 +82,14 @@ class HomeView(BaseView):
             return
         bid = event.button.id or ""
         if bid == "run-checkup":
-            event.button.disabled = True
+            self._set_buttons(False)
             self._set_ai_summary(None)
             results = self.query_one("#checkup-results", Vertical)
             await results.remove_children()
             await results.mount(Static("[dim]Running checkup…[/dim]", classes="subtle"))
             self.run_checkup_worker()
+        elif bid == "run-agent":
+            self._run_agent_flow()
         elif bid.startswith("fix-"):
             domain = bid.removeprefix("fix-")
             if domain in _DIRECT_FIX_LABELS:
@@ -112,11 +115,71 @@ class HomeView(BaseView):
             anomalies = []
         self.app.call_from_thread(self._show_findings, findings, anomalies)
 
+    def _set_buttons(self, enabled: bool) -> None:
+        for bid in ("run-checkup", "run-agent"):
+            try:
+                self.query_one(f"#{bid}", Button).disabled = not enabled
+            except Exception:
+                pass
+
+    # ------------------------------------------------------------ proactive run
+    @work
+    async def _run_agent_flow(self) -> None:
+        ok = await self.app.push_screen_wait(ConfirmModal(
+            "Run a maintenance pass? Sifty checks everything and cleans low-risk "
+            "cache/temp junk to the Recycle Bin (undoable from Reports).",
+            confirm_label="Run",
+        ))
+        if not ok:
+            return
+        self._set_buttons(False)
+        self._set_ai_summary(None)
+        results = self.query_one("#checkup-results", Vertical)
+        await results.remove_children()
+        await results.mount(Static("[dim]Running maintenance agent…[/dim]", classes="subtle"))
+        self.run_agent_worker()
+
+    @work(thread=True, exclusive=True, group="home-checkup")
+    def run_agent_worker(self) -> None:
+        try:
+            # Suppress the toast: the result is shown right here on screen.
+            result = agent_run.run_agent(apply=True, notify_fn=lambda _t, _m: True)
+        except Exception:
+            logger.exception("Home: agent run failed")
+            result = None
+        self.app.call_from_thread(self._show_agent_result, result)
+
+    async def _show_agent_result(self, result) -> None:
+        self._set_buttons(True)
+        if result is None:
+            try:
+                results = self.query_one("#checkup-results", Vertical)
+                await results.remove_children()
+                await results.mount(Static("Agent run failed - see `sifty logs`.", classes="subtle"))
+            except Exception:
+                pass
+            return
+        await self._show_findings(result.findings, result.anomalies)
+        try:
+            results = self.query_one("#checkup-results", Vertical)
+        except Exception:
+            return
+        if result.auto_fixed:
+            a = result.auto_fixed
+            await results.mount(Static(
+                f"[green]✓[/green] Auto-cleaned {a.items:,} items "
+                f"({human_size(a.bytes_freed)}) to the Recycle Bin · undo from Reports",
+                classes="status"))
+        if result.elevated_skipped:
+            await results.mount(Static(
+                f"[dim]{len(result.elevated_skipped)} admin-only categor(y/ies) left alone; "
+                f"use Elevate (F2) to include them.[/dim]", classes="status"))
+
     async def _show_findings(self, findings: list[Finding],
                              anomalies: list[Anomaly] | None = None) -> None:
         anomalies = anomalies or []
+        self._set_buttons(True)
         try:
-            self.query_one("#run-checkup", Button).disabled = False
             results = self.query_one("#checkup-results", Vertical)
         except Exception:
             return  # view was navigated away mid-scan

--- a/src/sifty/tui/views/home.py
+++ b/src/sifty/tui/views/home.py
@@ -12,14 +12,18 @@ from __future__ import annotations
 
 import logging
 
+from rich.markdown import Markdown
 from rich.text import Text
 from textual import work
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical
 from textual.widgets import Button, Static
 
+from ...ai import advisor
+from ...ai.client import OllamaClient
 from ...console import human_size
-from ...core import checkup, cleanup, disk, history, junk, updates
+from ...core import anomaly, checkup, cleanup, disk, history, junk, updates
+from ...core.anomaly import Anomaly
 from ...core.checkup import Finding
 from ...windows.admin import is_admin
 from ..modals import ConfirmModal
@@ -61,17 +65,24 @@ class HomeView(BaseView):
             )
             with Horizontal(classes="actions"):
                 yield Button("Run checkup", id="run-checkup", variant="primary")
+            yield Static("", id="ai-summary", classes="subtle")
             yield Vertical(id="checkup-results")
         yield Panel(Static("Reading volumes…", id="vol-body"), title="Volumes")
 
     def on_mount(self) -> None:
         self._findings: dict[str, Finding] = {}
+        self.query_one("#ai-summary", Static).display = False  # shown only when the AI summarizes
         self._render_volumes()  # fast (psutil), no worker needed
 
     async def on_button_pressed(self, event: Button.Pressed) -> None:
+        nav_key = getattr(event.button, "_nav_key", None)
+        if nav_key:  # an anomaly "Review…" button - jump to the owning screen
+            await self.app.show(nav_key)
+            return
         bid = event.button.id or ""
         if bid == "run-checkup":
             event.button.disabled = True
+            self._set_ai_summary(None)
             results = self.query_one("#checkup-results", Vertical)
             await results.remove_children()
             await results.mount(Static("[dim]Running checkup…[/dim]", classes="subtle"))
@@ -93,9 +104,17 @@ class HomeView(BaseView):
         except Exception:
             logger.exception("Home: checkup failed")
             findings = []
-        self.app.call_from_thread(self._show_findings, findings)
+        try:
+            anomalies = anomaly.detect()
+            anomaly.record_snapshot()  # keep the baseline fresh from interactive use
+        except Exception:
+            logger.exception("Home: anomaly detection failed")
+            anomalies = []
+        self.app.call_from_thread(self._show_findings, findings, anomalies)
 
-    async def _show_findings(self, findings: list[Finding]) -> None:
+    async def _show_findings(self, findings: list[Finding],
+                             anomalies: list[Anomaly] | None = None) -> None:
+        anomalies = anomalies or []
         try:
             self.query_one("#run-checkup", Button).disabled = False
             results = self.query_one("#checkup-results", Vertical)
@@ -116,10 +135,46 @@ class HomeView(BaseView):
             if f.severity != "ok" and f.action_key:
                 label = _DIRECT_FIX_LABELS.get(f.domain, f.action_label or "Review…")
                 await row.mount(Button(label, id=f"fix-{f.domain}", classes="fix"))
-        issues = sum(1 for f in findings if f.severity != "ok")
+        for i, a in enumerate(anomalies):
+            dot = _SEVERITY_DOT.get(a.severity, "")
+            row = Horizontal(classes="finding-row", id=f"anomaly-{i}")
+            await results.mount(row)
+            await row.mount(Static(f"{dot} [b]Change noticed[/b] - {a.summary}", classes="finding-text"))
+            if a.action_key:  # deep-link to the owning screen; selection is never an action
+                btn = Button("Review…", classes="fix")
+                btn._nav_key = a.action_key
+                await row.mount(btn)
+        issues = sum(1 for f in findings if f.severity != "ok") + len(anomalies)
         verdict = (f"[b]{issues}[/b] item(s) worth a look." if issues
                    else "[green]All clear - nothing needs attention.[/green]")
         await results.mount(Static(verdict, classes="status"))
+        # Only ping the local model when there's something to summarize.
+        if issues:
+            self.run_ai_summary_worker(findings, anomalies)
+
+    # -------------------------------------------------------------- AI summary
+    @work(thread=True, exclusive=True, group="home-aisummary")
+    def run_ai_summary_worker(self, findings: list[Finding], anomalies: list[Anomaly]) -> None:
+        try:
+            client = OllamaClient.from_config()
+            summary = advisor.summarize_checkup(client, findings, anomalies) \
+                if client.is_available() else None
+        except Exception:
+            logger.exception("Home: AI summary failed")
+            summary = None
+        self.app.call_from_thread(self._set_ai_summary, summary)
+
+    def _set_ai_summary(self, summary: str | None) -> None:
+        try:
+            banner = self.query_one("#ai-summary", Static)
+        except Exception:
+            return
+        if summary:
+            banner.update(Markdown(summary))
+            banner.display = True
+        else:
+            banner.update("")
+            banner.display = False
 
     # -------------------------------------------------------------- direct fix
     @work

--- a/tests/test_agent_run.py
+++ b/tests/test_agent_run.py
@@ -1,0 +1,143 @@
+"""Tests for the proactive agent run - especially the unattended auto-fix rails."""
+
+from __future__ import annotations
+
+import pytest
+
+from sifty.core import anomaly, checkup, disk, history, junk
+from sifty.core.agent_run import _AUTOFIX_ALLOWLIST, eligible_autofix_keys, run_agent
+from sifty.core.models import CategoryScan, CleanResult, JunkCategory
+from sifty.infra.config import DEFAULTS, Config, _deep_merge
+
+_GB = 1 << 30
+
+
+@pytest.fixture
+def temp_appdata(monkeypatch, tmp_path):
+    monkeypatch.setenv("APPDATA", str(tmp_path))
+    return tmp_path
+
+
+def _cfg(**agent_overrides) -> Config:
+    return Config(data=_deep_merge(DEFAULTS, {"agent": agent_overrides} if agent_overrides else {}))
+
+
+def _cat(key: str, size: int, admin: bool = False) -> CategoryScan:
+    return CategoryScan(JunkCategory(key, key, "", [], requires_admin=admin), size, 1, [])
+
+
+def _finding(domain="junk", severity="attention", summary="1.0 GB reclaimable"):
+    return checkup.Finding(domain, domain.title(), summary, severity, domain, "Fix")
+
+
+@pytest.fixture
+def stub_scans(monkeypatch):
+    """Stub the read-only scans + anomaly writes so tests don't touch the machine."""
+    monkeypatch.setattr(checkup, "run_checkup", lambda: [_finding()])
+    monkeypatch.setattr(disk, "volumes", lambda: [])
+    monkeypatch.setattr(anomaly, "detect", lambda **k: [])
+    monkeypatch.setattr(anomaly, "record_snapshot", lambda **k: None)
+    # Category list for the admin-exclusion check inside eligible_autofix_keys.
+    monkeypatch.setattr(junk, "junk_categories", lambda config=None: [
+        JunkCategory("user-temp", "", "", [], requires_admin=False),
+        JunkCategory("windows-temp", "", "", [], requires_admin=True),
+    ])
+
+
+# --- the core safety invariant ---------------------------------------------
+
+def test_allowlist_contains_no_admin_categories(monkeypatch, tmp_path):
+    # Populate env so every category is actually constructed, then verify none
+    # of the auto-fix allowlist keys are declared admin in junk.py.
+    for var in ("TEMP", "LOCALAPPDATA", "APPDATA"):
+        monkeypatch.setenv(var, str(tmp_path))
+    cats = {c.key: c for c in junk.junk_categories()}
+    for key in _AUTOFIX_ALLOWLIST:
+        if key in cats:
+            assert cats[key].requires_admin is False, f"{key} is an admin category!"
+    admin_keys = {k for k, c in cats.items() if c.requires_admin}
+    assert _AUTOFIX_ALLOWLIST.isdisjoint(admin_keys)
+
+
+def test_config_cannot_widen_allowlist(temp_appdata, stub_scans):
+    # User tries to add admin/system categories; they must be dropped.
+    cfg = _cfg(auto_fix_categories=["user-temp", "windows-temp", "windows-old"])
+    assert eligible_autofix_keys(cfg) == {"user-temp"}
+
+
+# --- run_agent behaviour ----------------------------------------------------
+
+def test_notify_only_by_default_never_cleans(temp_appdata, stub_scans, monkeypatch):
+    cleaned = []
+    monkeypatch.setattr(junk, "scan", lambda config=None: [_cat("user-temp", 5 * _GB)])
+    monkeypatch.setattr(junk, "clean", lambda *a, **k: cleaned.append(k) or CleanResult(0, 0, [], []))
+    toasts = []
+    result = run_agent(apply=False, config=_cfg(), notify_fn=lambda t, m: toasts.append(m) or True)
+
+    assert cleaned == []                 # apply=False => never deletes
+    assert result.auto_fixed is None
+    assert result.notified is True and toasts  # it did toast the finding
+
+
+def test_apply_cleans_only_allowlisted_keys(temp_appdata, stub_scans, monkeypatch):
+    captured = {}
+
+    def fake_clean(config=None, only=None, *, dry_run=True, extra_protected=None):
+        captured["only"] = only
+        captured["dry_run"] = dry_run
+        return CleanResult(3 * _GB, 42, [], [])
+
+    monkeypatch.setattr(junk, "scan", lambda config=None: [
+        _cat("user-temp", 3 * _GB),          # allowlisted
+        _cat("windows-temp", 9 * _GB, admin=True),  # admin -> excluded
+    ])
+    monkeypatch.setattr(junk, "clean", fake_clean)
+    recorded = {}
+    monkeypatch.setattr(history, "record_clean",
+                        lambda *a, **k: recorded.update(action=a[0], detail=a[1]) or 7)
+
+    result = run_agent(apply=True, config=_cfg(auto_fix_min_bytes=100),
+                       notify_fn=lambda t, m: True)
+
+    # Cleans the whole low-risk allowlist; the admin category is never passed.
+    assert captured["only"] == set(_AUTOFIX_ALLOWLIST)
+    assert "windows-temp" not in captured["only"]
+    assert captured["dry_run"] is False
+    assert result.auto_fixed is not None
+    assert result.auto_fixed.run_id == 7          # recorded -> undoable
+    assert recorded["action"] == "agent"
+
+
+def test_below_min_bytes_is_notify_only(temp_appdata, stub_scans, monkeypatch):
+    cleaned = []
+    monkeypatch.setattr(junk, "scan", lambda config=None: [_cat("user-temp", 10 * 1024 * 1024)])  # 10 MB
+    monkeypatch.setattr(junk, "clean", lambda *a, **k: cleaned.append(1) or CleanResult(0, 0, [], []))
+    result = run_agent(apply=True, config=_cfg(auto_fix_min_bytes=500 * 1024 * 1024),
+                       notify_fn=lambda t, m: True)
+    assert cleaned == []
+    assert result.auto_fixed is None
+
+
+def test_elevated_skipped_reports_admin_junk(temp_appdata, stub_scans, monkeypatch):
+    monkeypatch.setattr(junk, "scan", lambda config=None: [
+        _cat("user-temp", 1 * _GB),
+        _cat("windows-temp", 2 * _GB, admin=True),
+    ])
+    result = run_agent(apply=False, config=_cfg(), notify_fn=lambda t, m: True)
+    assert result.elevated_skipped == ["windows-temp"]
+
+
+def test_toast_failure_does_not_raise(temp_appdata, stub_scans, monkeypatch):
+    monkeypatch.setattr(junk, "scan", lambda config=None: [_cat("user-temp", 1 * _GB)])
+    result = run_agent(apply=False, config=_cfg(), notify_fn=lambda t, m: False)
+    assert result.notified is False
+
+
+def test_all_clear_sends_no_toast(temp_appdata, stub_scans, monkeypatch):
+    monkeypatch.setattr(checkup, "run_checkup", lambda: [_finding(severity="ok", summary="nothing to clean")])
+    monkeypatch.setattr(junk, "scan", lambda config=None: [])
+    toasts = []
+    result = run_agent(apply=False, config=_cfg(), notify_fn=lambda t, m: toasts.append(m) or True)
+    assert result.headline == ""
+    assert toasts == []            # don't nag when everything is fine
+    assert result.notified is False

--- a/tests/test_anomaly.py
+++ b/tests/test_anomaly.py
@@ -1,0 +1,74 @@
+"""Tests for anomaly detection (temp snapshot DB, no real OS scans)."""
+
+from __future__ import annotations
+
+import pytest
+
+from sifty.core import anomaly
+from sifty.core.models import VolumeUsage
+
+_GB = 1 << 30
+
+
+@pytest.fixture
+def temp_appdata(monkeypatch, tmp_path):
+    monkeypatch.setenv("APPDATA", str(tmp_path))
+    return tmp_path
+
+
+def _vol(mount: str, free: int) -> VolumeUsage:
+    return VolumeUsage("dev", mount, "NTFS", 100 * _GB, 100 * _GB - free, free)
+
+
+def test_first_run_has_no_anomalies(temp_appdata):
+    found = anomaly.detect(volumes=[_vol("C:\\", 60 * _GB)], junk_total=0, startup_names=[])
+    assert found == []
+
+
+def test_disk_drop_detected(temp_appdata):
+    anomaly.record_snapshot(volumes=[_vol("C:\\", 60 * _GB)], junk_total=0, startup_names=[])
+    found = anomaly.detect(volumes=[_vol("C:\\", 15 * _GB)], junk_total=0, startup_names=[])
+    drops = [a for a in found if a.kind == "disk_drop"]
+    assert len(drops) == 1
+    assert drops[0].severity == "attention"
+    assert drops[0].detail["mountpoint"] == "C:\\"
+
+
+def test_small_disk_drop_ignored(temp_appdata):
+    anomaly.record_snapshot(volumes=[_vol("C:\\", 60 * _GB)], junk_total=0, startup_names=[])
+    # 2 GB drop is below the 10 GB default threshold.
+    found = anomaly.detect(volumes=[_vol("C:\\", 58 * _GB)], junk_total=0, startup_names=[])
+    assert not any(a.kind == "disk_drop" for a in found)
+
+
+def test_junk_growth_detected(temp_appdata):
+    anomaly.record_snapshot(volumes=[], junk_total=1 * _GB, startup_names=[])
+    found = anomaly.detect(volumes=[], junk_total=7 * _GB, startup_names=[])
+    assert any(a.kind == "junk_growth" for a in found)
+
+
+def test_new_startup_detected(temp_appdata):
+    anomaly.record_snapshot(volumes=[], junk_total=0, startup_names=["Steam", "OneDrive"])
+    found = anomaly.detect(volumes=[], junk_total=0, startup_names=["Steam", "OneDrive", "SketchyApp"])
+    new = [a for a in found if a.kind == "new_startup"]
+    assert len(new) == 1
+    assert "SketchyApp" in new[0].detail["names"]
+
+
+def test_unchanged_startup_not_flagged(temp_appdata):
+    anomaly.record_snapshot(volumes=[], junk_total=0, startup_names=["Steam"])
+    found = anomaly.detect(volumes=[], junk_total=0, startup_names=["Steam"])
+    assert not any(a.kind == "new_startup" for a in found)
+
+
+def test_snapshot_pruning_bounds_series(temp_appdata):
+    for i in range(anomaly._KEEP_PER_SERIES + 15):
+        anomaly.record_snapshot(volumes=[_vol("C:\\", i)], junk_total=0, startup_names=[])
+    conn = anomaly._connect()
+    try:
+        n = conn.execute(
+            "SELECT COUNT(*) FROM snapshots WHERE kind='disk_free' AND key='C:\\'"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+    assert n <= anomaly._KEEP_PER_SERIES

--- a/tests/test_cli_agent.py
+++ b/tests/test_cli_agent.py
@@ -1,0 +1,50 @@
+"""Tests for the `sifty agent` CLI apply-decision boundary."""
+
+from __future__ import annotations
+
+import pytest
+
+from sifty.cli.commands import agent as agent_cli
+from sifty.core.agent_run import AgentRunResult
+
+
+@pytest.fixture
+def temp_appdata(monkeypatch, tmp_path):
+    monkeypatch.setenv("APPDATA", str(tmp_path))
+    return tmp_path
+
+
+def _empty_result() -> AgentRunResult:
+    return AgentRunResult([], [], None, False, "", [])
+
+
+@pytest.fixture
+def capture_apply(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(agent_cli.agent_run, "run_agent",
+                        lambda **kw: captured.update(kw) or _empty_result())
+    return captured
+
+
+def test_foreground_without_apply_is_read_only(temp_appdata, capture_apply):
+    agent_cli.run_cmd(apply=False, background=False)
+    assert capture_apply["apply"] is False
+
+
+def test_foreground_apply_flag_opts_in(temp_appdata, capture_apply):
+    agent_cli.run_cmd(apply=True, background=False)
+    assert capture_apply["apply"] is True
+
+
+def test_background_defaults_to_config_autofix_off(temp_appdata, capture_apply):
+    # No config file -> auto_fix defaults to False, so background does not delete.
+    agent_cli.run_cmd(apply=False, background=True)
+    assert capture_apply["apply"] is False
+
+
+def test_background_honours_config_autofix_on(temp_appdata, capture_apply, monkeypatch):
+    from sifty.infra.config import DEFAULTS, Config, _deep_merge
+    monkeypatch.setattr(agent_cli, "load_config",
+                        lambda: Config(data=_deep_merge(DEFAULTS, {"agent": {"auto_fix": True}})))
+    agent_cli.run_cmd(apply=False, background=True)
+    assert capture_apply["apply"] is True

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -66,3 +66,9 @@ def test_schedule_remove(temp_appdata, monkeypatch):
 def test_sifty_command_runs_clean_profile():
     cmd = schedule.sifty_command("weekly")
     assert "-m sifty clean --profile" in cmd and "--apply --yes" in cmd
+
+
+def test_agent_command_is_background_and_not_apply():
+    cmd = schedule.agent_command()
+    assert "-m sifty agent run --background" in cmd
+    assert "--apply" not in cmd  # the scheduled task is never forced to delete

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from textual.widgets import Button, DataTable, Input, Select, SelectionList, Static, Tree
 
 from sifty.core.apps import InstalledApp
@@ -39,6 +40,13 @@ from sifty.tui.views import (
 
 def _make_app() -> SiftyApp:
     return SiftyApp(start_workers=False)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_appdata(monkeypatch, tmp_path):
+    # Keep TUI tests off the real %APPDATA% (ai_memory.db conversation history,
+    # snapshots, etc.) so stored state can't leak into or pollute a test.
+    monkeypatch.setenv("APPDATA", str(tmp_path))
 
 
 def test_command_palette_entries_cover_sections_and_admin():

--- a/tests/test_tui_views.py
+++ b/tests/test_tui_views.py
@@ -384,6 +384,8 @@ async def test_home_run_checkup_button(monkeypatch):
     monkeypatch.setattr(
         "sifty.core.checkup.run_checkup", lambda: [Finding("disk", "Disk", "ok", "ok", "", "")]
     )
+    monkeypatch.setattr("sifty.core.anomaly.detect", lambda **k: [])
+    monkeypatch.setattr("sifty.core.anomaly.record_snapshot", lambda **k: None)
     async with _make_app().run_test() as pilot:
         await pilot.pause()
         await pilot.click("#run-checkup")

--- a/tests/test_tui_views.py
+++ b/tests/test_tui_views.py
@@ -394,6 +394,34 @@ async def test_home_run_checkup_button(monkeypatch):
         assert pilot.app.query(".finding-row")
 
 
+async def test_home_run_agent_button(monkeypatch):
+    from sifty.core.agent_run import AgentRunResult, AutoFixOutcome
+    from sifty.core.checkup import Finding
+
+    captured = {}
+
+    def fake_run_agent(**kw):
+        captured.update(kw)
+        return AgentRunResult(
+            [Finding("junk", "Junk files", "cleaned", "ok", "junk", "")],
+            [], AutoFixOutcome(["user-temp"], 5, 1000, [], 9), False, "done", [],
+        )
+
+    monkeypatch.setattr("sifty.core.agent_run.run_agent", fake_run_agent)
+    async with _make_app().run_test() as pilot:
+        await pilot.pause()
+        await pilot.click("#run-agent")
+        await pilot.pause()
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, ConfirmModal)
+        await pilot.click("#confirm")
+        await pilot.pause()
+        await pilot.pause()
+        await pilot.pause()
+        assert captured.get("apply") is True     # the button opts into auto-fix
+        assert pilot.app.query(".finding-row")   # result rendered on Home
+
+
 async def test_home_fix_junk_confirmed(monkeypatch):
     from sifty.core.checkup import Finding
 


### PR DESCRIPTION
Adds `sifty agent run` / `agent schedule`: a background checkup plus anomaly scan that toasts a summary, with an optional auto-fix.

Highlights:
- Anomaly detection (`core/anomaly.py`): a small local baseline flags a fast free-space drop, junk piling up, or a new startup program.
- Proactive run (`core/agent_run.py`): notify-only by default. Unattended auto-fix is opt-in (`[agent].auto_fix`), limited to a hardcoded per-user cache/temp allowlist, never admin or system paths, and never lets the model choose what to delete. Everything goes to the Recycle Bin and stays undoable.
- Home shows anomalies as reviewable rows and, when Ollama is running, a short AI summary of the checkup.

655 tests pass; version bumped to 0.9.0.

Heads up: hold the merge until 0.8.0 is released (Fri 2026-07-17). main needs to stay at 0.8.0 so the scheduled publish still fires, so merge this right after.
