### PR TITLE
(feat) add VS Code cache category to junk cleaner

### DIFF
--- a/src/sifty/core/junk.py
+++ b/src/sifty/core/junk.py
@@ -97,6 +97,28 @@ def _discord_cache_roots() -> list[Path]:
 
     return roots
 
+def _vscode_cache_roots() -> list[Path]:
+    """Cache directories for VS Code (stable channel).
+
+    Only returns the Chromium/V8 cache subfolders - never ``User``, which
+    holds settings, keybindings, and extensions.
+    """
+    roots: list[Path] = []
+    appdata = _env_path("APPDATA")
+    if not appdata:
+        return roots
+
+    code_dir = appdata / "Code"
+    if not code_dir.is_dir():
+        return roots
+
+    for sub in ("Cache", "CachedData", "Code Cache", "GPUCache"):
+        cand = code_dir / sub
+        if cand.is_dir():
+            roots.append(cand)
+
+    return roots
+
 def junk_categories(config=None) -> list[JunkCategory]:
     """Build the list of junk categories from the environment + config."""
     config = config or load_config()
@@ -224,6 +246,18 @@ def junk_categories(config=None) -> list[JunkCategory]:
                 "discord-cache", "Discord cache",
                 "On-disk caches for Discord, PTB, and Canary channels (never login session data).",
                 discord_roots,
+            )
+        )
+
+    # VS Code cache (Chromium/V8 style, safe to clear)
+    vscode_roots = _vscode_cache_roots()
+    if vscode_roots:
+        cats.append(
+            JunkCategory(
+                "vscode-cache", "VS Code cache",
+                "On-disk caches for VS Code (never the User folder - settings, "
+                "keybindings, and extensions).",
+                vscode_roots,
             )
         )
 

--- a/tests/test_junk.py
+++ b/tests/test_junk.py
@@ -140,6 +140,41 @@ def test_discord_cache_category_covers_flavors_and_safeguards_session(monkeypatc
     assert not any("Local Storage" in r for r in roots)
 
 
+def test_vscode_cache_category_covers_cache_dirs_and_protects_user_folder(monkeypatch, tmp_path):
+    appdata = tmp_path / "appdata"
+
+    code_dir = appdata / "Code"
+    (code_dir / "Cache").mkdir(parents=True)
+    (code_dir / "CachedData").mkdir(parents=True)
+    (code_dir / "Code Cache").mkdir(parents=True)
+    (code_dir / "GPUCache").mkdir(parents=True)
+    (code_dir / "User").mkdir(parents=True)
+
+    original_env_path = junk._env_path
+    monkeypatch.setattr(junk, "_env_path", lambda var: appdata if var == "APPDATA" else original_env_path(var))
+
+    monkeypatch.setenv("TEMP", str(tmp_path / "temp"))
+    monkeypatch.setenv("TMP", str(tmp_path / "temp"))
+    monkeypatch.setenv("SystemRoot", str(tmp_path / "win"))
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path / "home"))
+
+    cats = {c.key: c for c in junk.junk_categories(Config())}
+
+    # Verification 1: Category exists
+    assert "vscode-cache" in cats
+
+    roots = {str(r) for r in cats["vscode-cache"].roots}
+
+    # Verification 2: Specific caches are included
+    assert str(code_dir / "Cache") in roots
+    assert str(code_dir / "CachedData") in roots
+    assert str(code_dir / "Code Cache") in roots
+    assert str(code_dir / "GPUCache") in roots
+
+    # Verification 3: Settings/extensions folder is never touched
+    assert not any("User" in r for r in roots)
+
+
 def test_installer_app_hint_strips_suffixes():
     """Verify that installer filenames are properly cleaned into app hints."""
     assert junk._installer_app_hint(Path("Discord-Setup-1.2.3.exe")) == "discord setup"


### PR DESCRIPTION
Closes #19

Adds a `vscode-cache` junk category for VS Code's cache dirs under `%APPDATA%\Code`, following the same pattern as the existing `discord-cache` category.

**Covered:** `Cache`, `CachedData`, `Code Cache`, `GPUCache`
**Never touched:** `User` (settings, keybindings, extensions)

Scoped to the stable channel only for this PR - see the discussion on #19, happy to add VS Code Insiders as a follow-up if wanted.

**Testing**
- New sandbox test in `tests/test_junk.py`, mirrors the existing discord-cache test
- `pytest` - 636 passed
- `ruff check .` - clean
