### PR TITLE
(feat) add python and windows version to doctor output

### DIFF
--- a/src/sifty/cli/app.py
+++ b/src/sifty/cli/app.py
@@ -226,6 +226,7 @@ def doctor_cmd() -> None:
     import winreg
 
     import psutil
+    import platform
 
     from ..ai.client import OllamaClient
     from ..infra.config import audit_log_path
@@ -235,6 +236,8 @@ def doctor_cmd() -> None:
     has_winget = winget.available()
     client = OllamaClient.from_config()
     ollama_up = client.is_available()
+    py_version = platform.python_version()
+    win_version = platform.version()
 
     # Free space on the system volume.
     sys_root = os.environ.get("SystemDrive", "C:") + "\\"
@@ -274,6 +277,8 @@ def doctor_cmd() -> None:
 
     if output.json_enabled():
         output.emit({
+            "python_version": py_version,
+            "windows_version": win_version,
             "administrator": admin,
             "winget": has_winget,
             "disk_free_gb": round(disk_free_gb, 2),
@@ -289,6 +294,8 @@ def doctor_cmd() -> None:
     def _ok(v: bool) -> str:
         return "[green]yes[/green]" if v else "[red]no[/red]"
 
+    console.print(f"Python Version:   {py_version}")
+    console.print(f"Windows Version:  {win_version}")
     console.print(f"Administrator:    {'[green]yes[/green]' if admin else '[yellow]no[/yellow] (some tasks need it)'}")
     console.print(f"winget:           {'[green]available[/green]' if has_winget else '[red]missing[/red]'}")
 


### PR DESCRIPTION
## What does this PR do?

 Log python and windows versions when using sifty doctor (also added to json output)
Resolves #22 
## Safety checklist

Sifty deletes files, so every PR keeps these promises:

- [X] `pytest` is green, including `tests/test_safety.py`
- [X] No new direct deletions (`os.remove`, `shutil.rmtree`, `Path.unlink`); everything goes through `safety.trash()`
- [X] New destructive paths default to dry-run and ask before applying
- [X] New core functions have a matching test

## Notes for the reviewer

<!-- Anything you're unsure about, trade-offs, or things to look at closely. -->
