### PR TITLE
(enhance) compact purge clean output

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,8 @@ sifty update check           # available updates (winget)
 sifty update apply           # upgrade everything (asks first)
 
 # Developer cleanup
-sifty purge clean            # node_modules, dist, __pycache__, target, …
+sifty purge clean .          # compact summary of node_modules, dist, __pycache__, target, …
+sifty purge clean . --details # show every matching directory and full path
 sifty cleanup duplicates D:\Photos   # de-duplicate (keeps one copy each)
 sifty cleanup large C:\Users\you     # biggest files under a path
 sifty cleanup stale --days 180       # old items in Downloads
@@ -204,7 +205,7 @@ Clean, Disk, Apps, Monitor, Reports, AI):
 - **Home**: volume gauges and a **Run checkup** button that scans everything
   at once; findings come with buttons that fix them right there (clean junk,
   clean stale downloads, apply updates, each behind a confirm).
-- **Clean**: Junk / Purge / Optimize / Smart cleanup under one roof (tabs).
+- **Clean**: Junk / Purge / Optimize / Smart cleanup under one roof (tabs); Purge groups artifact directories by type, largest first.
 - **Apps**: Installed / Updates / Startup / Services, with fuzzy filter,
   sorting, bulk uninstall, and an automatic leftover scan after uninstalling.
 - **AI**: an agentic chat where proposed tool runs show **Run/Skip buttons

--- a/src/sifty/cli/commands/purge.py
+++ b/src/sifty/cli/commands/purge.py
@@ -6,12 +6,42 @@ from pathlib import Path
 
 import typer
 from rich.table import Table
+from rich.text import Text
 
 from ...console import confirm, console, human_size, success, warn
 from ...core import history, purge
 from .. import output
 
 app = typer.Typer(no_args_is_help=True, help="Find and remove dev artifact directories (node_modules, dist, __pycache__, …).")
+
+
+def _print_artifacts(
+    artifacts: list[purge.ArtifactScan], *, title: str, details: bool = True
+) -> None:
+    """Render artifacts selected by a purge scan."""
+    total = sum(a.size_bytes for a in artifacts)
+    if details:
+        console.print(Text(title, style="bold"))
+        for artifact in artifacts:
+            line = f"{artifact.pattern}  {human_size(artifact.size_bytes):>10}  {artifact.path}"
+            console.print(Text(line), crop=False, overflow="ignore")
+        console.print(Text(f"Total: {len(artifacts):,} directories, {human_size(total)}", style="bold"))
+        return
+
+    table = Table(title=title)
+    table.add_column("Pattern", style="dim")
+    table.add_column("Directories", justify="right")
+    table.add_column("Size", justify="right")
+    grouped: dict[str, tuple[int, int]] = {}
+    for artifact in artifacts:
+        count, size = grouped.get(artifact.pattern, (0, 0))
+        grouped[artifact.pattern] = (count + 1, size + artifact.size_bytes)
+    for pattern, (count, size) in sorted(grouped.items(), key=lambda item: item[1][1], reverse=True):
+        table.add_row(pattern, f"{count:,}", human_size(size))
+
+    table.add_section()
+    table.add_row("[bold]Total[/bold]", f"[bold]{len(artifacts):,}[/bold]", f"[bold]{human_size(total)}[/bold]")
+    console.print(table)
 
 
 @app.command("scan")
@@ -36,17 +66,7 @@ def scan_cmd(
         success(f"No artifact directories found under {path}.")
         return
 
-    table = Table(title=f"Artifact directories under {path}")
-    table.add_column("Pattern", style="dim")
-    table.add_column("Size", justify="right")
-    table.add_column("Path")
-    total = 0
-    for a in artifacts:
-        table.add_row(a.pattern, human_size(a.size_bytes), str(a.path))
-        total += a.size_bytes
-    table.add_section()
-    table.add_row("", f"[bold]{human_size(total)}[/bold]", f"[dim]{len(artifacts):,} directories[/dim]")
-    console.print(table)
+    _print_artifacts(artifacts, title=f"Artifact directories under {path}")
     console.print("\nRun [cyan]sifty purge clean PATH --apply[/cyan] to remove them.")
 
 
@@ -55,6 +75,7 @@ def clean_cmd(
     path: Path = typer.Argument(..., help="Root directory to clean."),
     apply: bool = typer.Option(False, "--apply", help="Actually move artifacts to the Recycle Bin."),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip the confirmation prompt."),
+    details: bool = typer.Option(False, "--details", help="Show every matching directory and its full path."),
 ) -> None:
     """Remove dev artifact directories under PATH (dry-run unless --apply)."""
     path = path.expanduser()
@@ -70,6 +91,7 @@ def clean_cmd(
         return
 
     total = sum(a.size_bytes for a in artifacts)
+    _print_artifacts(artifacts, title=f"Artifact summary under {path}", details=details)
     console.print(
         f"Found [bold]{len(artifacts):,}[/bold] artifact directories "
         f"totalling [bold]{human_size(total)}[/bold]."

--- a/src/sifty/tui/views/purge.py
+++ b/src/sifty/tui/views/purge.py
@@ -25,13 +25,13 @@ _UNMARK = " "
 
 
 class PurgeView(BaseView):
-    BINDINGS = [("space", "toggle_mark", "Mark")]
+    BINDINGS = [("space", "toggle_mark", "Mark group")]
 
     def compose(self) -> ComposeResult:
         yield Static("Dev artifact purge", classes="title")
         yield Static(
             "Scans a project tree for node_modules, dist, __pycache__, target, and "
-            "other build artefacts. Mark rows (click / Space) and purge selected.",
+            "other build artefacts. Groups are selectable by type.",
             classes="subtle",
         )
         yield Input(value=str(Path.home()), id="purge-path", placeholder="Project root to scan")
@@ -50,7 +50,9 @@ class PurgeView(BaseView):
         self._marked: set[str] = set()
         table = self.query_one("#purge-table", DataTable)
         table.cursor_type = "row"
-        self._cols = table.add_columns("", "Pattern", "Size", "Path")
+        table.add_columns("", "Pattern", "Directories", "Size")
+        self._groups: dict[str, list[purge.ArtifactScan]] = {}
+        self._group_keys: list[str] = []
         self.query_one("#purge-panel").display = False
         self.query_one("#purge-actions").display = False
 
@@ -109,6 +111,9 @@ class PurgeView(BaseView):
     def _populate(self, artifacts: list[purge.ArtifactScan]) -> None:
         self._artifacts = artifacts
         self._marked = {str(a.path) for a in artifacts}  # pre-mark all
+        self._groups = {}
+        for artifact in artifacts:
+            self._groups.setdefault(artifact.pattern, []).append(artifact)
         self.query_one("#purge-table", DataTable).loading = False
         if not artifacts:
             self.query_one("#purge-panel").display = False
@@ -122,29 +127,47 @@ class PurgeView(BaseView):
     def _rebuild_table(self) -> None:
         table = self.query_one("#purge-table", DataTable)
         table.clear()
-        for a in self._artifacts:
-            mark = _MARK if str(a.path) in self._marked else _UNMARK
-            table.add_row(mark, a.pattern, human_size(a.size_bytes), str(a.path), key=str(a.path))
+        groups = sorted(
+            self._groups.items(),
+            key=lambda item: sum(a.size_bytes for a in item[1]),
+            reverse=True,
+        )
+        self._group_keys = [pattern for pattern, _artifacts in groups]
+        for pattern, artifacts in groups:
+            paths = {str(a.path) for a in artifacts}
+            selected = len(paths & self._marked)
+            mark = _MARK if selected == len(paths) else "~" if selected else _UNMARK
+            total = sum(a.size_bytes for a in artifacts)
+            table.add_row(mark, pattern, f"{len(artifacts):,}", human_size(total), key=pattern)
         total = sum(a.size_bytes for a in self._artifacts if str(a.path) in self._marked)
         self._status(
             f"{len(self._artifacts)} directories · {len(self._marked)} marked "
-            f"({human_size(total)})"
+            f"({human_size(total)}) · {len(self._groups)} groups"
         )
 
     def _toggle_mark(self, key: str) -> None:
+        group = self._groups.get(key)
+        if group is not None:
+            paths = {str(a.path) for a in group}
+            if paths <= self._marked:
+                self._marked.difference_update(paths)
+            else:
+                self._marked.update(paths)
+            self._rebuild_table()
+            return
+
+        # Keep path toggling available for callers and older integrations that
+        # address an individual artifact directly.
         if key in self._marked:
             self._marked.discard(key)
-            self.query_one("#purge-table", DataTable).update_cell(key, self._cols[0], _UNMARK)
         else:
             self._marked.add(key)
-            self.query_one("#purge-table", DataTable).update_cell(key, self._cols[0], _MARK)
-        total = sum(a.size_bytes for a in self._artifacts if str(a.path) in self._marked)
-        self._status(f"{len(self._artifacts)} directories · {len(self._marked)} marked ({human_size(total)})")
+        self._rebuild_table()
 
     def action_toggle_mark(self) -> None:
         table = self.query_one("#purge-table", DataTable)
-        if table.row_count and table.cursor_row is not None and 0 <= table.cursor_row < len(self._artifacts):
-            self._toggle_mark(str(self._artifacts[table.cursor_row].path))
+        if table.row_count and table.cursor_row is not None and 0 <= table.cursor_row < len(self._group_keys):
+            self._toggle_mark(self._group_keys[table.cursor_row])
 
     def on_data_table_row_selected(self, event: DataTable.RowSelected) -> None:
         if event.row_key and event.row_key.value:

--- a/tests/test_cli_actions.py
+++ b/tests/test_cli_actions.py
@@ -116,11 +116,30 @@ def test_cleanup_worktrees_apply(monkeypatch, tmp_path):
 
 
 def test_purge_clean_dry(monkeypatch, tmp_path):
-    artifact = SimpleNamespace(path=tmp_path / "dist", pattern="dist", size_bytes=100)
-    monkeypatch.setattr("sifty.core.purge.scan_artifacts", lambda p: [artifact])
+    artifacts = [
+        SimpleNamespace(path=tmp_path / "dist", pattern="dist", size_bytes=100),
+        SimpleNamespace(path=tmp_path / "node_modules", pattern="node_modules", size_bytes=200),
+    ]
+    monkeypatch.setattr("sifty.core.purge.scan_artifacts", lambda p: artifacts)
     result = runner.invoke(app, ["purge", "clean", str(tmp_path)])
     assert result.exit_code == 0
     assert "Dry-run" in result.stdout
+    assert "dist" in result.stdout
+    assert "node_modules" in result.stdout
+    assert str(tmp_path / "dist") not in result.stdout
+    assert str(tmp_path / "node_modules") not in result.stdout
+
+
+def test_purge_clean_details(monkeypatch, tmp_path):
+    artifacts = [
+        SimpleNamespace(path=tmp_path / "dist", pattern="dist", size_bytes=100),
+        SimpleNamespace(path=tmp_path / "node_modules", pattern="node_modules", size_bytes=200),
+    ]
+    monkeypatch.setattr("sifty.core.purge.scan_artifacts", lambda p: artifacts)
+    result = runner.invoke(app, ["purge", "clean", str(tmp_path), "--details"])
+    assert result.exit_code == 0
+    assert str(tmp_path / "dist") in result.stdout
+    assert str(tmp_path / "node_modules") in result.stdout
 
 
 def test_purge_clean_apply(monkeypatch, tmp_path):

--- a/tests/test_tui_views.py
+++ b/tests/test_tui_views.py
@@ -272,6 +272,32 @@ async def test_purge_scan_worker_and_marks(monkeypatch, tmp_path):
         assert view._marked == set()
 
 
+async def test_purge_groups_artifacts_by_pattern(tmp_path):
+    artifacts = [
+        _artifact(tmp_path, "dist", 1000),
+        _artifact(tmp_path, "node_modules", 5000),
+        _artifact(tmp_path, "node_modules-2", 3000),
+    ]
+    artifacts[1].pattern = "node_modules"
+    artifacts[2].pattern = "node_modules"
+    async with _make_app().run_test(size=(160, 60)) as pilot:
+        await pilot.app.show("purge")
+        await pilot.pause()
+        await pilot.pause()
+        view = pilot.app.query_one(PurgeView)
+        view._populate(artifacts)
+        await pilot.pause()
+        table = pilot.app.query_one("#purge-table", DataTable)
+        assert table.row_count == 2
+        assert view._group_keys == ["node_modules", "dist"]
+        assert view._marked == {str(a.path) for a in artifacts}
+
+        view._toggle_mark("node_modules")
+        assert view._marked == {str(artifacts[0].path)}
+        view._toggle_mark("node_modules")
+        assert view._marked == {str(a.path) for a in artifacts}
+
+
 async def test_purge_scan_empty(monkeypatch, tmp_path):
     monkeypatch.setattr("sifty.core.purge.scan_artifacts", lambda p: [])
     async with _make_app().run_test() as pilot:


### PR DESCRIPTION
### Hi guys!
I’ve just made a UI improvement to sifty purge clean: the list now shows everything grouped by Pattern, so it’s easier to see how many directories there are.

I also added another command, sifty purge clean --details, to show the full raw list like it did before.

<img width="645" height="416" alt="image" src="https://github.com/user-attachments/assets/a1a8ba29-c130-4243-811f-a2db830e6a3b" />
<img width="1159" height="761" alt="image" src="https://github.com/user-attachments/assets/75fd2689-5029-4deb-bc11-593ef66e71aa" />

---

I really like this project, and I think it has a lot of potential to become one of the best.

I just wish the purging were faster. It took more than an hour to clean everything, and my computer isn’t exactly low-end.
It was probably because I had a lot of __pycache__ folders, or because I was running the project locally—I’m not sure.

My PC configuration:
- SSD: 500 GB Kingston M.2
- CPU: Ryzen 7 5700G
- GPU: RTX 4060

By the way, I found this project through ChatGPT. I was looking for software that could identify leftover folders from software that had already been uninstalled, especially in AppData.

I tried BCUninstaller, Revo Uninstaller, and now this one, but I couldn’t find a way to do that with any of them.

So, if you have any recommendations for how I could do that, please let me know!

---

Anyway, thanks for all the work you’ve put into Sifty. I really enjoyed using it, and I hope these changes help. Keep it up!

> The code changes were made with codex.